### PR TITLE
fix race condition when observing multiple attributes for changes

### DIFF
--- a/lib/action_pubsub/exchanges.rb
+++ b/lib/action_pubsub/exchanges.rb
@@ -2,7 +2,8 @@ module ActionPubsub
   class Exchanges < ::ActionPubsub::Registry
     def register_queue(exchange_name, subscriber_name)
       queue_name = [exchange_name, subscriber_name].join("/")
-      self[exchange_name].add(subscriber_name) { ::ActionPubsub::Queue.spawn(queue_name) }
+      queue_exists = self[exchange_name].all.any?{ |queue| queue.name == queue_name }
+      self[exchange_name].add(subscriber_name) { ::ActionPubsub::Queue.spawn(queue_name) } unless queue_exists
     end
 
     def register_exchange(exchange_name)


### PR DESCRIPTION
This fixes a race condition that occurred when watching multiple attributes on change. I.e. since the registry is a Concurrent::LazyRegister, when watching two attributes on_change in subscriber, queue would get re registered, and wipe out the previously registered queue.
